### PR TITLE
Accept the recordingStartedAt parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -109,7 +109,7 @@ export interface IoStream {
    * Start streaming to and/or from the device.
    * @returns void when the stream has started.
    */
-  start(): void
+  start(recordingStartedAt: number): void
   /**
    * Quit the stream. Waits to process all pending bytes.
    * The optional callback will execute when the quit has completed.

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ function AudioIO(options) {
     });
   }
 
-  ioStream.start = () => audioIOAdon.start();
+  ioStream.start = (recordingStartedAt) => audioIOAdon.start(recordingStartedAt);
 
   ioStream.quit = async cb => {
     await audioIOAdon.quit('WAIT');
@@ -84,11 +84,10 @@ function AudioIO(options) {
       cb();
   }
 
-  ioStream.abort = cb => {
-    audioIOAdon.quit('ABORT', () => {
-      if (typeof cb === 'function')
-        cb();
-    });
+  ioStream.abort = async cb => {
+    await audioIOAdon.quit('ABORT')
+    if (typeof cb === 'function')
+      cb();
   }
 
   ioStream.on('close', async () => {

--- a/scratch/garrett.js
+++ b/scratch/garrett.js
@@ -63,17 +63,17 @@ function runAudio(fileName, sleepTime) {
       const chunkMs = chunk.length / 4 / 48;
       timeDeltaMs += currentTime - prevTimeMs - chunkMs;
       prevTimeMs = currentTime;
-      console.log('time delta:', timeDeltaMs);
+      //console.log('time delta:', timeDeltaMs);
       if (i === 20) {
         console.log('sleep-o');
         await sleep(sleepTime);
       }
 
-      console.log('before write', Date.now());
+      //console.log('before write', Date.now());
       const result = await write(chunk);
-      console.log('after write', Date.now());
+      //console.log('after write', Date.now());
       //await sleep(100);
-      console.log('result:', String(result));
+      //console.log('result:', String(result));
       if (result === false) {
         // Handle backpressure
         console.log('waito');
@@ -90,7 +90,7 @@ function runAudio(fileName, sleepTime) {
   //// Start piping data and start streaming
   rs.once('readable', async () => {
     console.log('STAHT');
-    ao.start();
+    ao.start(Date.now() - 2000);
     await pipeFileToSpeakers();
   });
 }

--- a/src/AudioIO.cc
+++ b/src/AudioIO.cc
@@ -145,7 +145,19 @@ napi_value AudioIO::Start(napi_env env, napi_callback_info info) {
   napi_status status;
   napi_value result;
 
-  mPaContext->start(env);
+  // Check argument count
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+  CHECK_STATUS;
+  if (argc != 1)
+    NAPI_THROW_ERROR("AudioIO Start expects 1 argument");
+
+  // Start context with recordingStartedAt argument
+  long long recordingStartedAt;
+  status = napi_get_value_int64(env, args[0], &recordingStartedAt);
+  CHECK_STATUS;
+  mPaContext->start(env, recordingStartedAt);
 
   status = napi_get_undefined(env, &result);
   CHECK_STATUS;
@@ -357,7 +369,7 @@ napi_value AudioIO::Quit(napi_env env, napi_callback_info info) {
   std::string stopFlagStr = stopFlag;
   if ((0 != stopFlagStr.compare("WAIT")) && (0 != stopFlagStr.compare("ABORT")))
     NAPI_THROW_ERROR("AudioIO Quit expects \'WAIT\' or \'ABORT\' as the first argument");
-  c->mStopFlag = (0 == stopFlagStr.compare("WAIT")) ? 
+  c->mStopFlag = (0 == stopFlagStr.compare("WAIT")) ?
     PaContext::eStopFlag::WAIT : PaContext::eStopFlag::ABORT;
 
   c->status = napi_create_string_utf8(env, "Quit", NAPI_AUTO_LENGTH, &resourceName);

--- a/src/PaContext.h
+++ b/src/PaContext.h
@@ -38,7 +38,7 @@ public:
   bool hasInput() { return mInOptions ? true : false; }
   bool hasOutput() { return mOutOptions ? true : false; }
 
-  void start(napi_env env);
+  void start(napi_env env, long long recordingStartedAt);
   void stop(eStopFlag flag);
 
   std::shared_ptr<Chunk> pullInChunk(uint32_t numBytes, bool &finished);


### PR DESCRIPTION
This change adds a `recordingStartedAt` parameter to `IoStream.start` so that the playback engine can skip samples it didn't get to play while things were initializing.